### PR TITLE
BE-FT-Endpoint-To-Resend-Email-Confirmation

### DIFF
--- a/apps/api/backend/src/auth/auth.controller.ts
+++ b/apps/api/backend/src/auth/auth.controller.ts
@@ -71,7 +71,7 @@ export class AuthController {
   }
 
   @Patch('email/change-password')
-  @ApiOperation({ summary: 'Change password the password' })
+  @ApiOperation({ summary: 'Change password' })
   @ApiResponse({
     status: HttpStatus.OK,
     description: 'The user password has been successfully changed.',

--- a/apps/api/backend/src/auth/auth.controller.ts
+++ b/apps/api/backend/src/auth/auth.controller.ts
@@ -53,6 +53,21 @@ export class AuthController {
     );
   }
 
+  @Post('resend-confirmation-link')
+  @ApiOperation({ summary: 'Resend confirmation link' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'The confirmation link has been successfully sent.',
+  })
+  public async resendConfirmationLink(
+    @Body() email: ValidateEmailDto,
+  ): Promise<{ message: string }> {
+    await this._authService.resendConfirmationLink(email.email);
+    return {
+      message: 'Confirmation Link Sent Successfully',
+    };
+  }
+
   @Post('email/login')
   @ApiOperation({ summary: 'Login with email/username and password' })
   @ApiResponse({

--- a/apps/api/backend/src/auth/auth.repository.ts
+++ b/apps/api/backend/src/auth/auth.repository.ts
@@ -35,6 +35,16 @@ export class AuthRepository {
     return data;
   }
 
+  public async resendConfirmationLink(email: string): Promise<any> {
+    const { error } = await this._supabase.auth.resend({
+      type: 'signup',
+      email,
+    });
+    if (error) {
+      throw new BaseException(error.message, error.status);
+    }
+  }
+
   public async emailLogin(
     email: string,
     password: string,

--- a/apps/api/backend/src/auth/auth.service.ts
+++ b/apps/api/backend/src/auth/auth.service.ts
@@ -24,6 +24,10 @@ export class AuthService {
     );
   }
 
+  public async resendConfirmationLink(email: string): Promise<any> {
+    await this._authRepository.resendConfirmationLink(email);
+  }
+
   public async emailLogin(
     authCredentials: IUserSignIn,
   ): Promise<IUserSignInResponse> {


### PR DESCRIPTION
## Summary
This is a feature to handle a scenario where a user did not receive an email confirmation, So the user has to hit another endpoint to resend email confirmation

## API endpoints
`POST /v1/auth/resend-confirmation-link - Resend confirmation link`
_Expected Response when the endpoint above is hit_
```
{
  "statusCode": 201,
  "data": {
    "message": "Confirmation Link Sent Successfully"
  }
}
```


## How Has This Been Tested?

- [ ] Unit Tests

**Test Configuration**:


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have added integration tests for this feature (if applicable).
- [ ] New and existing unit| integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] No error nor warning in the console.
- [ ] Deploy to staging